### PR TITLE
Do not specify the exact version of the Licence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "openeuropa/drupal-module-template",
     "description": "OpenEuropa Drupal module template.",
     "type": "drupal-module",
-    "license": "EUPL-1.2",
+    "license": "EUPL",
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {


### PR DESCRIPTION
When we added the EUPL licence to the Joinup project we have contacted the legal support team of the commission and they suggested us to declare that we require the `EUPL` licence without specifying a version. Let's also follow this advice from the legal team in OpenEuropa modules.