### PR TITLE
List of repositories in composer manifest should be an array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"
     },
-    "repositories": {
-        "drupal": {
+    "repositories": [
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
-    },
+    ],
     "autoload": {
         "psr-4": {
             "Drupal\\drupal_module_template\\": "./src/"


### PR DESCRIPTION
When I try to add another repository to the composer manifest using the instructions at the official Composer documentation (ref. [composer.json schema: repositories](https://getcomposer.org/doc/04-schema.md#repositories)) then I get the following error:

```
[Seld\JsonLint\ParsingException]               
  "./composer.json" does not contain valid JSON  
  Parse error on line 21:                        
  ...itories": {        {            "type"      
  ---------------------^                         
  Expected one of: 'STRING', '}
```

It appears that we have declared this parameter as a JSON object but the documentation strongly suggests to use an array so that the correct order of the repositories can be guaranteed when resolving the dependencies.

> Order is significant here. When looking for a package, Composer will look from the first to the last repository, and pick the first match. By default Packagist is added last which means that custom repositories can override packages from it.
> Using JSON object notation is also possible. However, JSON key/value pairs are to be considered unordered so consistent behaviour cannot be guaranteed.