### PR TITLE
OPENEUROPA-1520: Use drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "openeuropa/drupal-core-require": "^8.6",
+        "drupal/core": "^8.6",
         "php": "^7.1"
     },
     "require-dev": {


### PR DESCRIPTION
## OPENEUROPA-1520

### Description

Remove drupal-core-require and use drupal/core
### Change log

- Added:
- Changed: Remove drupal-core-require and use drupal/core
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

